### PR TITLE
fix #106

### DIFF
--- a/src/Gdk/GdkEvent.cpp
+++ b/src/Gdk/GdkEvent.cpp
@@ -2,13 +2,13 @@
 #include "GdkEvent.h"
 
 
-// 
+//
 GdkEvent *GdkEvent_::get_instance()
 {
     return instance;
 }
 
-// 
+//
 void GdkEvent_::set_instance(GdkEvent *event)
 {
     instance = event;
@@ -18,25 +18,9 @@ void GdkEvent_::set_instance(GdkEvent *event)
 void GdkEvent_::populate(GdkEvent *event)
 {
     instance = event;
-    
+
    // get self reference as Php::Value object
     Php::Value self(this);
-
-    // GdkEventType
-    self["type"] = event->type;
-    
-    // GtkEventButton
-    GdkEventButton_ *eventbutton_ = new GdkEventButton_();
-    Php::Value gdkeventbutton = Php::Object("GdkEventButton", eventbutton_);
-    eventbutton_->populate(event->button);
-    self["button"] = eventbutton_;
-
-    // GtkEventKey
-    GdkEventKey_ *eventkey_ = new GdkEventKey_();
-    Php::Value gdkeventkey = Php::Object("GdkEventKey", eventkey_);
-    eventkey_->populate(event->key);
-    self["key"] = eventkey_;
-
 
     /**
 
@@ -64,5 +48,5 @@ void GdkEvent_::populate(GdkEvent *event)
     };
 
     */
-    
+
 }

--- a/src/Gdk/GdkEventButton.cpp
+++ b/src/Gdk/GdkEventButton.cpp
@@ -7,7 +7,7 @@
  */
 GdkEventButton_::GdkEventButton_()
 {
-    
+
 }
 
 
@@ -15,19 +15,4 @@ void GdkEventButton_::populate(GdkEventButton event)
 {
    // get self reference as Php::Value object
     Php::Value self(this);
-
-    // initialize a public property
-    self["type"] = (int)event.type;
-    // self["window"] = (int)event.window;  // GdkWindow
-    self["send_event"] = (int)event.send_event;
-    self["time"] = (int)event.time;
-    self["x"] = (int)event.x;
-    self["y"] = (int)event.y;
-    self["axes"] = (double *)event.axes;
-    self["state"] = (int)event.state;
-    self["button"] = (int)event.button;
-    // self["device"] = (int)event.device;  // GdkDevice
-    self["x_root"] = (double)event.x_root;
-    self["y_root"] = (double)event.y_root;
-
 }

--- a/src/Gdk/GdkEventKey.cpp
+++ b/src/Gdk/GdkEventKey.cpp
@@ -7,35 +7,12 @@
  */
 GdkEventKey_::GdkEventKey_()
 {
-    
+
 }
 
 
 void GdkEventKey_::populate(GdkEventKey event)
 {
-    // Php::call("var_dump", "OK");
-
     // get self reference as Php::Value object
     Php::Value self(this);
-    // initialize a public property
-    self["type"] = (int)event.type;
-    // self["window"] = (int)event.window;  // GdkWindow
-    self["send_event"] = (int)event.send_event;
-    self["time"] = (int)event.time;
-    self["state"] = (int)event.state;
-    self["keyval"] = (int)event.keyval;
-    self["length"] = (int)event.length;
-
-    if(event.string != NULL) {
-        const gchar *event_string = event.string;
-        self["string"] = &event_string;
-    }
-
-    self["hardware_keycode"] = (int)event.hardware_keycode;
-    self["keycode"] = (int)event.hardware_keycode;
-    self["group"] = (int)event.group;
-    self["is_modifier"] = (int)event.is_modifier;
-    
-
-
 }


### PR DESCRIPTION
that's just an attempt to fix #106

I have removed some _extra_ constructions, 
now everything work without warnings by using previous events model

```
Deprecated: Creation of dynamic property GdkEvent::$type is deprecated...
```

But not sure what is the reason of previous implementation as re-defines each event object (that for some reasons not available in my PHP 8.3.9 environment)

Any comments?