### PR TITLE
fix GdkEvent, GdkEventButton, GdkEventKey properties initiation #106

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -504,14 +504,25 @@ extern "C"
 
         // GdkEvent
         Php::Class<GdkEvent_> gdkevent("GdkEvent");
-        // gdkevent.method<&GdkEvent_::__construct>("__construct");
+        gdkevent.method<&GdkEvent_::__construct>("__construct");
         // gdkevent.method<&GdkEvent_::__get>("__get");
-        // gdkevent.property("type", 0);
+        gdkevent.property("type", NULL);
+        gdkevent.property("button", NULL);
+        gdkevent.property("key", NULL);
 
         // GdkEventButton
         Php::Class<GdkEventButton_> gdkeventbutton("GdkEventButton");
-        // gdkevent.method<&GdkEvent_::__construct>("__construct");
-        // gdkevent.property("type", 0);
+        gdkeventbutton.method<&GdkEventButton_::__construct>("__construct");
+        gdkeventbutton.property("type", NULL);
+        gdkeventbutton.property("send_event", NULL);
+        gdkeventbutton.property("time", NULL);
+        gdkeventbutton.property("x", NULL);
+        gdkeventbutton.property("y", NULL);
+        gdkeventbutton.property("axes", NULL);
+        gdkeventbutton.property("state", NULL);
+        gdkeventbutton.property("button", NULL);
+        gdkeventbutton.property("x_root", NULL);
+        gdkeventbutton.property("y_root", NULL);
 
         // GdkCursor
         Php::Class<GdkCursor_> gdkcursor("GdkCursor");
@@ -664,6 +675,18 @@ extern "C"
 
         // GdkEventKey
         Php::Class<GdkEventKey_> gdkeventkey("GdkEventKey");
+        gdkeventkey.method<&GdkEventKey_::__construct>("__construct");
+        gdkeventkey.property("type", NULL);
+        gdkeventkey.property("send_event", NULL);
+        gdkeventkey.property("time", NULL);
+        gdkeventkey.property("state", NULL);
+        gdkeventkey.property("keyval", NULL);
+        gdkeventkey.property("length", NULL);
+        gdkeventkey.property("string", NULL);
+        gdkeventkey.property("hardware_keycode", NULL);
+        gdkeventkey.property("keycode", NULL);
+        gdkeventkey.property("group", NULL);
+        gdkeventkey.property("is_modifier", NULL);
 
         // GdkEventType
         Php::Class<Php::Base> gdkeventtype("GdkEventType");
@@ -741,7 +764,7 @@ extern "C"
         gdkpixbuf.method<&GdkPixbuf_::set_data>("set_data");
         gdkpixbuf.method<&GdkPixbuf_::get_data>("get_data");
         gdkpixbuf.method<&GdkPixbuf_::get_byte_length>("get_byte_length");
-        
+
 
         // GdkInterpType
         Php::Class<Php::Base> gdkinterptype("GdkInterpType");

--- a/src/Gdk/GdkEvent.h
+++ b/src/Gdk/GdkEvent.h
@@ -9,7 +9,7 @@
     #include "GdkEventKey.h"
 
     /**
-     * 
+     *
      */
     class GdkEvent_ : public Php::Base
     {
@@ -24,9 +24,14 @@
              */
             GdkEvent_() = default;
             virtual ~GdkEvent_() = default;
-            // 
+            //
             GdkEvent *get_instance();
             void set_instance(GdkEvent *event);
+
+            /**
+             * PHP Construct
+             */
+            void __construct(Php::Parameters &parameters);
 
             /**
              * Populate GdkEvent to PHPGTK::GDKEVENT

--- a/src/Gdk/GdkEventButton.h
+++ b/src/Gdk/GdkEventButton.h
@@ -6,7 +6,7 @@
     #include <gtk/gtk.h>
 
     /**
-     * 
+     *
      */
     class GdkEventButton_ : public Php::Base
     {
@@ -19,6 +19,11 @@
              *  C++ constructor and destructor
              */
             GdkEventButton_();
+
+            /**
+             * PHP Construct
+             */
+            void __construct(Php::Parameters &parameters);
 
             /**
              * Populate GdkEventButton to PHPGTK::GdkEventButton

--- a/src/Gdk/GdkEventKey.h
+++ b/src/Gdk/GdkEventKey.h
@@ -6,7 +6,7 @@
     #include <gtk/gtk.h>
 
     /**
-     * 
+     *
      */
     class GdkEventKey_ : public Php::Base
     {
@@ -19,6 +19,11 @@
              *  C++ constructor and destructor
              */
             GdkEventKey_();
+
+            /**
+             * PHP Construct
+             */
+            void __construct(Php::Parameters &parameters);
 
             /**
              * Populate GdkEventKey to PHPGTK::GdkEventKey


### PR DESCRIPTION
Solution for GDK warnings (#106)

> can you provide a simple code with the problem?

This issue happens on:

  * keypress on entry
  * button click event

Common `GdkEvent` (that implements `GdkEventButton`, `GdkEventKey`) also drop warnings for `type`, `key`, `button`.

```
Deprecated: Creation of dynamic property GdkEventButton::$type is deprecated in /home/i/Apps/yggverse/Yoda/src/Yoda.php on line 39

Deprecated: Creation of dynamic property GdkEventButton::$send_event is deprecated in /i/ibox/Apps/yggverse/Yoda/src/Yoda.php on line 39

Deprecated: Creation of dynamic property GdkEventButton::$time is deprecated in /home/i/Apps/yggverse/Yoda/src/Yoda.php on line 39

Deprecated: Creation of dynamic property GdkEventButton::$x is deprecated in /home/i/Apps/yggverse/Yoda/src/Yoda.php on line 39

Deprecated: Creation of dynamic property GdkEventButton::$y is deprecated in /home/i/Apps/yggverse/Yoda/src/Yoda.php on line 39
...
```

This solution resolve the problem using nullable properties initiation on __construct.
Resulting event dump in testing application looks well (as designed)

``` php
        $entry->connect(
            'key-release-event',
            function (
                \GtkEntry $entry,
                \GdkEvent $event
            ) {
                var_dump($event);
            }
        );
```

```
object(GdkEvent)#71 (3) {
  ["type"]=>
  int(9)
  ["button"]=>
  object(GdkEventButton)#72 (10) {
    ["type"]=>
    int(9)
    ["send_event"]=>
    int(0)
    ["time"]=>
    int(4611196)
    ["x"]=>
    int(0)
    ["y"]=>
    int(0)
    ["axes"]=>
    bool(true)
    ["state"]=>
    int(41)
    ["button"]=>
    int(0)
    ["x_root"]=>
    float(0)
    ["y_root"]=>
    float(0)
  }
  ["key"]=>
  object(GdkEventKey)#73 (11) {
    ["type"]=>
    int(9)
    ["send_event"]=>
    int(0)
    ["time"]=>
    int(4611196)
    ["state"]=>
    int(16)
    ["keyval"]=>
    int(102)
    ["length"]=>
    int(1)
    ["string"]=>
    bool(true)
    ["hardware_keycode"]=>
    int(41)
    ["keycode"]=>
    int(41)
    ["group"]=>
    int(0)
    ["is_modifier"]=>
    int(0)
  }
}
```