### PR TITLE
fix GtkStyleProvider constants namespace

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -377,13 +377,13 @@ extern "C"
         gtkstylecontextprintflags.constant("RECURSE", GTK_STYLE_CONTEXT_PRINT_RECURSE);
         gtkstylecontextprintflags.constant("SHOW_STYLE", GTK_STYLE_CONTEXT_PRINT_SHOW_STYLE);
 
-        // GtkStyleProviderPriority
-        Php::Class<Php::Base> gtkstyleproviderpriority("GtkStyleProviderPriority");
-        gtkstyleproviderpriority.constant("APPLICATION", GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-        gtkstyleproviderpriority.constant("FALLBACK", GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
-        gtkstyleproviderpriority.constant("SETTINGS", GTK_STYLE_PROVIDER_PRIORITY_SETTINGS);
-        gtkstyleproviderpriority.constant("THEME", GTK_STYLE_PROVIDER_PRIORITY_THEME);
-        gtkstyleproviderpriority.constant("USER", GTK_STYLE_PROVIDER_PRIORITY_USER);
+        // GtkStyleProvider
+        Php::Class<Php::Base> gtkstyleprovider("GtkStyleProvider");
+        gtkstyleprovider.constant("PRIORITY_APPLICATION", GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+        gtkstyleprovider.constant("PRIORITY_FALLBACK", GTK_STYLE_PROVIDER_PRIORITY_FALLBACK);
+        gtkstyleprovider.constant("PRIORITY_SETTINGS", GTK_STYLE_PROVIDER_PRIORITY_SETTINGS);
+        gtkstyleprovider.constant("PRIORITY_THEME", GTK_STYLE_PROVIDER_PRIORITY_THEME);
+        gtkstyleprovider.constant("PRIORITY_USER", GTK_STYLE_PROVIDER_PRIORITY_USER);
 
         // ----- ENUMS
         extension.add(std::move(gtkwidgethelptype));
@@ -394,7 +394,7 @@ extern "C"
         extension.add(std::move(gtkjunctionsides));
         extension.add(std::move(gtkregionflags));
         extension.add(std::move(gtkstylecontextprintflags));
-        extension.add(std::move(gtkstyleproviderpriority));
+        extension.add(std::move(gtkstyleprovider));
 
         // ----- GDK
         // Gdk
@@ -3866,7 +3866,7 @@ extern "C"
         pangowrapmode.constant("WORD", (int)PANGO_WRAP_WORD);
         pangowrapmode.constant("CHAR", (int)PANGO_WRAP_CHAR);
         pangowrapmode.constant("WORD_CHAR", (int)PANGO_WRAP_WORD_CHAR);
-      
+
         // PangoContext
         Php::Class<PangoContext_> pangocontext("PangoContext");
         pangocontext.extends(gobject);


### PR DESCRIPTION
NS update for #121

``` php
<?php

\Gtk::init();

var_dump(\GtkStyleProvider::PRIORITY_APPLICATION); // int(600)
var_dump(\GtkStyleProvider::PRIORITY_FALLBACK); // int(1)
var_dump(\GtkStyleProvider::PRIORITY_SETTINGS); // int(400)
var_dump(\GtkStyleProvider::PRIORITY_THEME); // int(200)
var_dump(\GtkStyleProvider::PRIORITY_USER); // int(800)

\Gtk::main();
```

_p.s. forgot to disable empty lines filter in vscode - but there is only one [line](https://github.com/scorninpc/php-gtk3/pull/129/commits/04bd25a2729c0e97e3b80807d11dc8022b1bcb5e#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL3869) :)_