### PR TITLE
add new methods, init PangoLayout_::get_line dependencies

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3873,6 +3873,10 @@ extern "C"
         gtkdrawingarea.extends(gtkwidget);
         gtkdrawingarea.method<&GtkDrawingArea_::__construct>("__construct");
 
+        // Pango
+        Php::Class<Php::Base> pango("Pango");
+        pango.constant("SCALE", (int)PANGO_SCALE);
+
         // PangoWrapMode
         Php::Class<Php::Base> pangowrapmode("PangoWrapMode");
         pangowrapmode.constant("WORD", (int)PANGO_WRAP_WORD);
@@ -3883,6 +3887,20 @@ extern "C"
         Php::Class<PangoContext_> pangocontext("PangoContext");
         pangocontext.extends(gobject);
         pangocontext.method<&PangoContext_::__construct>("__construct");
+
+        // PangoLayout
+        Php::Class<PangoLayout_> pangolayout("PangoLayout");
+        pangolayout.extends(gobject);
+        pangolayout.method<&PangoLayout_::__construct>("__construct");
+        pangolayout.method<&PangoLayout_::set_text>("set_text");
+        pangolayout.method<&PangoLayout_::set_width>("set_width");
+        pangolayout.method<&PangoLayout_::get_line>("get_line");
+        pangolayout.method<&PangoLayout_::get_text>("get_text");
+        pangolayout.method<&PangoLayout_::get_width>("get_width");
+
+        // PangoLayoutLine
+        Php::Class<PangoLayoutLine_> pangolayoutline("PangoLayoutLine");
+        pangolayoutline.extends(gobject);
 
 #ifdef WITH_MAC_INTEGRATION
         // gtkosxapplication
@@ -4192,8 +4210,11 @@ extern "C"
 
         extension.add(std::move(gtkarrowtype));
 
+        extension.add(std::move(pango));
         extension.add(std::move(pangowrapmode));
         extension.add(std::move(pangocontext));
+        extension.add(std::move(pangolayout));
+        extension.add(std::move(pangolayoutline));
 
 #ifdef WITH_MAC_INTEGRATION
         extension.add(std::move(gtkosxapplication));

--- a/main.h
+++ b/main.h
@@ -154,6 +154,9 @@
 
 	// Pango
 	#include "src/Pango/PangoContext.h"
+	#include "src/Pango/PangoLayout.h"
+	#include "src/Pango/PangoLayoutLine.h"
+	#include "src/Pango/PangoWrapMode.h"
 
 #ifdef WITH_MAC_INTEGRATION
 	// GtkosxApplication

--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -1,0 +1,57 @@
+#include "PangoLayout.h"
+
+/**
+ * Constructor
+ */
+PangoLayout_::PangoLayout_() = default;
+
+/**
+ * Destructor
+ */
+PangoLayout_::~PangoLayout_() = default;
+
+void PangoLayout_::__construct(Php::Parameters &parameters)
+{
+	Php::Value object_pango_context = parameters[0];
+	PangoContext_ *pango_context = (PangoContext_*) object_pango_context.implementation();
+
+	instance = (gpointer*) pango_layout_new (PANGO_CONTEXT(pango_context->get_instance()));
+}
+
+void PangoLayout_::set_text(Php::Parameters &parameters)
+{
+	std::string s_text = parameters[0];
+	gchar* text = (gchar*) s_text.c_str();
+
+	gint length = (gint) parameters[1];
+
+	pango_layout_set_text(PANGO_LAYOUT(instance), text, length);
+}
+
+void PangoLayout_::set_width(Php::Parameters &parameters)
+{
+	gint width = (gint) parameters[0];
+
+	pango_layout_set_width(PANGO_LAYOUT(instance), width);
+}
+
+Php::Value PangoLayout_::get_line(Php::Parameters &parameters)
+{
+	throw Php::Exception("PangoLayout::get_line not implemented");
+
+	/* @TODO 
+	gint line = (gint) parameters[0];
+
+	return pango_layout_get_line(PANGO_LAYOUT(instance), line);
+	*/
+}
+
+Php::Value PangoLayout_::get_text()
+{
+	return pango_layout_get_text(PANGO_LAYOUT(instance));
+}
+
+Php::Value PangoLayout_::get_width()
+{
+	return pango_layout_get_width(PANGO_LAYOUT(instance));
+}

--- a/src/Pango/PangoLayout.h
+++ b/src/Pango/PangoLayout.h
@@ -1,0 +1,38 @@
+
+#ifndef _PHPGTK_PANGOLAYOUT_H_
+#define _PHPGTK_PANGOLAYOUT_H_
+
+    #include <phpcpp.h>
+
+    #include "../G/GObject.h"
+
+    #include "PangoContext.h"
+    #include "PangoLayoutLine.h"
+
+    class PangoLayout_ : public GObject_
+    {
+        /**
+         * Publics
+         */
+        public:
+
+            /**
+             *  C++ constructor and destructor
+             */
+            PangoLayout_();
+            ~PangoLayout_();
+
+            void __construct(Php::Parameters &parameters);
+
+            void set_text(Php::Parameters &parameters);
+
+            void set_width(Php::Parameters &parameters);
+
+            Php::Value get_line(Php::Parameters &parameters);
+
+            Php::Value get_text();
+
+            Php::Value get_width();
+    };
+
+#endif

--- a/src/Pango/PangoLayoutLine.cpp
+++ b/src/Pango/PangoLayoutLine.cpp
@@ -1,0 +1,11 @@
+#include "PangoLayoutLine.h"
+
+/**
+ * Constructor
+ */
+PangoLayoutLine_::PangoLayoutLine_() = default;
+
+/**
+ * Destructor
+ */
+PangoLayoutLine_::~PangoLayoutLine_() = default;

--- a/src/Pango/PangoLayoutLine.h
+++ b/src/Pango/PangoLayoutLine.h
@@ -1,0 +1,25 @@
+
+#ifndef _PHPGTK_PANGOLAYOUTLINE_H_
+#define _PHPGTK_PANGOLAYOUTLINE_H_
+
+    #include <phpcpp.h>
+
+    #include "../G/GObject.h"
+
+    #include "PangoLayout.h"
+
+    class PangoLayoutLine_ : public GObject_
+    {
+        /**
+         * Publics
+         */
+        public:
+
+            /**
+             *  C++ constructor and destructor
+             */
+            PangoLayoutLine_();
+            ~PangoLayoutLine_();
+    };
+
+#endif


### PR DESCRIPTION
Implemented new methods, initiated new classes, added `Pango::SCALE` const.
but stuck with `PangoLayout_::get_line` struct implementation #131 so added an exception as todo.

I think that must construct new `PangoLayoutLine_` class with attributes returned by
https://docs.gtk.org/Pango/method.Layout.get_lines.html

but not sure, maybe this solution is better:
https://github.com/scorninpc/php-gtk3/blob/5992f0119902998a50b7d3ab96c42758092cd48b/src/Gtk/GtkTreeView.cpp#L309

or this one for example:
https://github.com/scorninpc/php-gtk3/blob/5992f0119902998a50b7d3ab96c42758092cd48b/src/Gdk/GdkEventButton.cpp

Anyway, other simple methods are implemented. But not sure I can complete `get_line` because my cpp skills not enough or I don't understand the gtk-php3 model yet. Have some drafts but removed them from commit.

Maybe somebody wish to continue other methods, `get_line` including

I've tested these changes with following code (without UI):

``` php 
<?php 

// Initialize
Gtk::init();

// new const
var_dump(
    Pango::SCALE // OK
);

// constructor
$layout = new PangoLayout(
    (new GtkDrawingArea)->create_pango_context()
);

// text
$layout->set_text('test', 2); // OK

var_dump(
    $layout->get_text() // OK
);

// width
$layout->set_width(3 * Pango::SCALE); // OK

var_dump(
    $layout->get_width() // OK
);

// line
var_dump(
    $layout->get_line(0) // @TODO
);

Gtk::main();
```