### PR TITLE
add missed Gtk::main()

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ $win->connect("destroy", "GtkWindowDestroy");
 
 // Show window
 $win->show_all();
+
+// Start
+Gtk::main();
 ```
 
 ## Involved


### PR DESCRIPTION
I suppose `Gtk::main()` missed in readme, because current example does not work as expected