### PR TITLE
implement PangoLayout_::xy_to_index

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3901,6 +3901,7 @@ extern "C"
         pangolayout.method<&PangoLayout_::get_line>("get_line");
         pangolayout.method<&PangoLayout_::get_text>("get_text");
         pangolayout.method<&PangoLayout_::get_width>("get_width");
+        pangolayout.method<&PangoLayout_::xy_to_index>("xy_to_index");
 
         // PangoLayoutLine
         Php::Class<PangoLayoutLine_> pangolayoutline("PangoLayoutLine");

--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -71,13 +71,13 @@ Php::Value PangoLayout_::xy_to_index(Php::Parameters &parameters)
 	if (result) {
 
 		// @TODO wanted canonical implementation
-		// where params returned as generated arguments and return Php::Type::True;
+		// where params return as generated parameters 2,3 and method return Php::Type::True;
 		// https://docs.gtk.org/Pango/method.Layout.xy_to_index.html #143
 
 		Php::Array params;
 
-		params["index_"] = index_;
-		params["trailing"] = trailing;
+		params["index_"] = (int) index_;
+		params["trailing"] = (int) trailing;
 
 		return params;
 

--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -81,5 +81,7 @@ Php::Value PangoLayout_::xy_to_index(Php::Parameters &parameters)
 
 		return params;
 
-	} else return Php::Type::False;
+	}
+
+	return Php::Type::False;
 }

--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -55,3 +55,31 @@ Php::Value PangoLayout_::get_width()
 {
 	return pango_layout_get_width(PANGO_LAYOUT(instance));
 }
+
+Php::Value PangoLayout_::xy_to_index(Php::Parameters &parameters)
+{
+	gint x = (gint) parameters[0]; // * Pango::SCALE
+	gint y = (gint) parameters[1]; // * Pango::SCALE
+
+	gint index_;
+	gint trailing;
+
+	gboolean result = pango_layout_xy_to_index(
+		PANGO_LAYOUT(instance), x, y, &index_, &trailing
+	);
+
+	if (result) {
+
+		// @TODO wanted canonical implementation
+		// where params returned as generated arguments and return Php::Type::True;
+		// https://docs.gtk.org/Pango/method.Layout.xy_to_index.html #143
+
+		Php::Array params;
+
+		params["index_"] = index_;
+		params["trailing"] = trailing;
+
+		return params;
+
+	} else return Php::Type::False;
+}

--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -70,10 +70,6 @@ Php::Value PangoLayout_::xy_to_index(Php::Parameters &parameters)
 
 	if (result) {
 
-		// @TODO wanted canonical implementation
-		// where params return as generated parameters 2,3 and method return Php::Type::True;
-		// https://docs.gtk.org/Pango/method.Layout.xy_to_index.html #143
-
 		Php::Array params;
 
 		params["index_"] = (int) index_;

--- a/src/Pango/PangoLayout.h
+++ b/src/Pango/PangoLayout.h
@@ -33,6 +33,8 @@
             Php::Value get_text();
 
             Php::Value get_width();
+
+            Php::Value xy_to_index(Php::Parameters &parameters);
     };
 
 #endif


### PR DESCRIPTION
This function work, but has changed API that returns `index` and `trailing` to PHP as array, not arguments linked.

Please DO NOT merge at this point, I'll try to implement it 1:1 compatible with documentation API
https://docs.gtk.org/Pango/method.Layout.xy_to_index.html

#143

``` php 
//...

$this->gtk->connect(
    'button-press-event',
    function(
        GtkLabel $label,
        GdkEvent $event
    ) {

        if ($event->button->button == Gdk::BUTTON_MIDDLE)
        {
            // $index = null;
            // $trailing = null;

            $result = $label->get_layout()->xy_to_index(
                $event->button->x * Pango::SCALE,
                $event->button->y * Pango::SCALE,
               // $index,
               // $trailing
            );

            var_dump($result); // index & trailing here

            // var_dump($index);
            // var_dump($trailing);
        }

        return true;
    }
);
```