### PR TITLE
init PangoAttrList

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3881,6 +3881,12 @@ extern "C"
         Php::Class<Php::Base> pango("Pango");
         pango.constant("SCALE", (int)PANGO_SCALE);
 
+        // PangoAttrList
+        Php::Class<PangoAttrList_> pangoattrlist("PangoAttrList");
+        pangoattrlist.extends(gobject);
+        pangoattrlist.method<&PangoAttrList_::__construct>("__construct");
+        pangoattrlist.method<&PangoAttrList_::get_attributes>("get_attributes");
+
         // PangoWrapMode
         Php::Class<Php::Base> pangowrapmode("PangoWrapMode");
         pangowrapmode.constant("WORD", (int)PANGO_WRAP_WORD);
@@ -4215,6 +4221,7 @@ extern "C"
         extension.add(std::move(gtkarrowtype));
 
         extension.add(std::move(pango));
+        extension.add(std::move(pangoattrlist));
         extension.add(std::move(pangowrapmode));
         extension.add(std::move(pangocontext));
         extension.add(std::move(pangolayout));

--- a/main.h
+++ b/main.h
@@ -153,6 +153,7 @@
 	#include "src/Glade/GladeWidget.h"
 
 	// Pango
+	#include "src/Pango/PangoAttrList.h"
 	#include "src/Pango/PangoContext.h"
 	#include "src/Pango/PangoLayout.h"
 	#include "src/Pango/PangoLayoutLine.h"

--- a/src/Pango/PangoAttrList.cpp
+++ b/src/Pango/PangoAttrList.cpp
@@ -1,0 +1,40 @@
+#include "PangoAttrList.h"
+
+/**
+ * Constructor
+ */
+PangoAttrList_::PangoAttrList_() = default;
+
+/**
+ * Destructor
+ */
+PangoAttrList_::~PangoAttrList_() = default;
+
+void PangoAttrList_::__construct()
+{
+	instance = (gpointer *)pango_attr_list_new ();
+}
+
+Php::Value PangoAttrList_::get_attributes()
+{
+	throw Php::Exception("PangoAttrList::get_attributes() not implemented");
+
+	/*
+	GSList *ret = pango_attr_list_get_attributes(PANGO_ATTR_LIST(instance));
+
+	Php::Value ret_arr;
+
+	for(int index=0; GSList *item=g_slist_nth(ret, index); index++) {
+
+		PangoAttribute_ *return_parsed = new PangoAttribute_();
+
+		return_parsed->set_instance(
+			(gpointer *)PANGO_ATTRIBUTE(item->data) // @TODO
+		);
+
+		ret_arr[index] = Php::Object("PangoAttribute", return_parsed);
+	}
+	
+	return ret_arr;
+	*/
+}

--- a/src/Pango/PangoAttrList.h
+++ b/src/Pango/PangoAttrList.h
@@ -1,0 +1,27 @@
+
+#ifndef _PHPGTK_PANGOATTRLIST_H_
+#define _PHPGTK_PANGOATTRLIST_H_
+
+    #include <phpcpp.h>
+
+    #include "../G/GObject.h"
+
+    class PangoAttrList_ : public GObject_
+    {
+        /**
+         * Publics
+         */
+        public:
+
+            /**
+             *  C++ constructor and destructor
+             */
+            PangoAttrList_();
+            ~PangoAttrList_();
+
+            void __construct();
+
+            Php::Value get_attributes();
+    };
+
+#endif


### PR DESCRIPTION
Initial set for https://docs.gtk.org/Pango/struct.AttrList.html

contains only one method `get_attributes` drafted (requires PangoAttribute implementation)

``` php 
<?php

$pangoAttrList = new PangoAttrList; // OK

var_dump(
    $pangoAttrList->get_attributes() // @TODO not implemented exception
);
```