### PR TITLE
implement PangoLayout::get_line()

### DIFF
--- a/src/Pango/PangoLayout.cpp
+++ b/src/Pango/PangoLayout.cpp
@@ -35,15 +35,57 @@ void PangoLayout_::set_width(Php::Parameters &parameters)
 	pango_layout_set_width(PANGO_LAYOUT(instance), width);
 }
 
+/**
+ * https://docs.gtk.org/Pango/method.Layout.get_line.html
+ */
 Php::Value PangoLayout_::get_line(Php::Parameters &parameters)
 {
-	throw Php::Exception("PangoLayout::get_line not implemented");
-
-	/* @TODO 
 	gint line = (gint) parameters[0];
 
-	return pango_layout_get_line(PANGO_LAYOUT(instance), line);
-	*/
+	PangoLayoutLine* ret = pango_layout_get_line(
+		PANGO_LAYOUT(instance), line
+	);
+
+	if (ret)
+	{
+		/**
+		 * Build PangoLayoutLine
+		 * https://docs.gtk.org/Pango/struct.LayoutLine.html
+		 */
+
+		Php::Array ret_arr;
+
+		PangoLayout_ *return_parsed = new PangoLayout_();
+
+		return_parsed->set_instance(
+			(gpointer *)PANGO_LAYOUT(ret->layout)
+		);
+
+		ret_arr["layout"] = Php::Object("PangoLayout", return_parsed);
+		ret_arr["start_index"] = (int) ret->start_index;
+		ret_arr["length"] = (int) ret->length;
+
+		// @TODO
+		// ret_arr["runs"] = Php::Object("GSList", ret->runs);
+
+		/**
+		 * TRUE if this is the first line of the paragraph (by documentation)
+		 */
+		if (ret->is_paragraph_start == true) {
+			ret_arr["is_paragraph_start"] = Php::Type::True;
+		} else {
+			ret_arr["is_paragraph_start"] = (int) ret->is_paragraph_start;
+		}
+
+		/**
+		 * https://docs.gtk.org/Pango/enum.Direction.html
+		 */
+		ret_arr["resolved_dir"] = (int) ret->resolved_dir;
+
+		return ret_arr;
+	}
+
+	return Php::Type::Null;
 }
 
 Php::Value PangoLayout_::get_text()


### PR DESCRIPTION
https://docs.gtk.org/Pango/method.Layout.get_line.html

Implemented everything but `GSList* runs;` value in struct (currently not wanted for me)
https://docs.gtk.org/Pango/struct.LayoutLine.html

``` php 
<?php

// Initialize
Gtk::init();

// init some testing data
$layout = new PangoLayout(
    (new GtkDrawingArea)->create_pango_context()
);

$layout->set_text("test", 4);

// try out of line
var_dump(
    $layout->get_line(1) // return NULL - OK
);

// try existing line
$pangoLayoutLine = $layout->get_line(0);

var_dump(
    $pangoLayoutLine // test struct - OK
);

// test layout class init
var_dump(
    $pangoLayoutLine["layout"]->get_text() // OK
);
```