### PR TITLE
implement Gtk::show_uri_on_window

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -861,6 +861,7 @@ extern "C"
         gtk.method<&Gtk_::main_quit>("main_quit");
         gtk.method<&Gtk_::timeout_add>("timeout_add");
         gtk.method<&Gtk_::source_remove>("source_remove");
+        gtk.method<&Gtk_::show_uri_on_window>("show_uri_on_window");
         gtk.method<&Gtk_::events_pending>("events_pending");
         gtk.method<&Gtk_::main_iteration>("main_iteration");
 

--- a/main.cpp
+++ b/main.cpp
@@ -864,6 +864,9 @@ extern "C"
         gtk.method<&Gtk_::show_uri_on_window>("show_uri_on_window");
         gtk.method<&Gtk_::events_pending>("events_pending");
         gtk.method<&Gtk_::main_iteration>("main_iteration");
+        gtk.method<&Gtk_::get_major_version>("get_major_version");
+        gtk.method<&Gtk_::get_micro_version>("get_micro_version");
+        gtk.method<&Gtk_::get_minor_version>("get_minor_version");
 
         gtk.constant("ORIENTATION_HORIZONTAL", GTK_ORIENTATION_HORIZONTAL);
         gtk.constant("ORIENTATION_VERTICAL", GTK_ORIENTATION_VERTICAL);

--- a/main.cpp
+++ b/main.cpp
@@ -868,6 +868,10 @@ extern "C"
         gtk.method<&Gtk_::get_micro_version>("get_micro_version");
         gtk.method<&Gtk_::get_minor_version>("get_minor_version");
 
+        gtk.constant("MAJOR_VERSION", GTK_MAJOR_VERSION);
+        gtk.constant("MICRO_VERSION", GTK_MICRO_VERSION);
+        gtk.constant("MINOR_VERSION", GTK_MINOR_VERSION);
+
         gtk.constant("ORIENTATION_HORIZONTAL", GTK_ORIENTATION_HORIZONTAL);
         gtk.constant("ORIENTATION_VERTICAL", GTK_ORIENTATION_VERTICAL);
 

--- a/src/Gtk/Gtk.cpp
+++ b/src/Gtk/Gtk.cpp
@@ -122,6 +122,36 @@ Php::Value Gtk_::main_iteration()
 	return gtk_main_iteration();
 }
 
+/**
+ * https://docs.gtk.org/gtk3/func.get_major_version.html
+ */
+Php::Value Gtk_::get_major_version()
+{
+    guint ret = gtk_get_major_version();
+
+    return (int) ret;
+}
+
+/**
+ * https://docs.gtk.org/gtk3/func.get_micro_version.html
+ */
+Php::Value Gtk_::get_micro_version()
+{
+    guint ret = gtk_get_micro_version();
+
+    return (int) ret;
+}
+
+/**
+ * https://docs.gtk.org/gtk3/func.get_minor_version.html
+ */
+Php::Value Gtk_::get_minor_version()
+{
+    guint ret = gtk_get_minor_version();
+
+    return (int) ret;
+}
+
 void Gtk_::init()
 {
     gtk_init(0, NULL);

--- a/src/Gtk/Gtk.cpp
+++ b/src/Gtk/Gtk.cpp
@@ -85,6 +85,32 @@ Php::Value Gtk_::source_remove(Php::Parameters &parameters)
     return ret;
 }
 
+/**
+ * https://docs.gtk.org/gtk3/func.show_uri_on_window.html
+ */
+Php::Value Gtk_::show_uri_on_window(Php::Parameters &parameters)
+{
+    // Init parent object
+    Php::Value object_parent = parameters[0];
+    GtkWindow *parent = NULL;
+
+    if (object_parent.instanceOf("GtkWindow")) {
+        GtkWindow_ *phpgtk_parent = (GtkWindow_ *)object_parent.implementation();
+        parent = GTK_WINDOW(phpgtk_parent->get_instance());
+    }
+
+    // Init URI
+    std::string s_uri = parameters[1];
+    char* uri = (char*)s_uri.c_str();
+
+    // @TODO
+    guint32 timestamp;
+    GError** error;
+    
+    gboolean ret = gtk_show_uri_on_window(parent, uri, timestamp, error);
+
+    return ret;
+}
 
 Php::Value Gtk_::events_pending()
 {

--- a/src/Gtk/Gtk.h
+++ b/src/Gtk/Gtk.h
@@ -56,6 +56,9 @@
 
 			static Php::Value events_pending();
 			static Php::Value main_iteration();
+			static Php::Value get_major_version();
+			static Php::Value get_micro_version();
+			static Php::Value get_minor_version();
 			static void init();
 
 	};

--- a/src/Gtk/Gtk.h
+++ b/src/Gtk/Gtk.h
@@ -7,6 +7,12 @@
 	#include <gtk/gtk.h>
 
 	/**
+	 * Dependency:
+	 *  show_uri_on_window
+	 */
+	#include "GtkWindow.h" 
+
+	/**
 	 *  
 	 */
 	class Gtk_ : public Php::Base
@@ -45,6 +51,7 @@
 
 			static Php::Value timeout_add(Php::Parameters &parameters);
 			static Php::Value source_remove(Php::Parameters &parameters);
+			static Php::Value show_uri_on_window(Php::Parameters &parameters);
 			static gint timeout_add_callback(gpointer data);
 
 			static Php::Value events_pending();


### PR DESCRIPTION
https://docs.gtk.org/gtk3/func.show_uri_on_window.html

Function requires window object, so let's use an example from readme for test

``` php
<?php

// Initialize
Gtk::init();

// Callback for when window is closed
function GtkWindowDestroy($widget=NULL, $event=NULL)
{
	Gtk::main_quit();
}

// Create a window
$win = new GtkWindow();
$win->set_default_size(300, 200);

// Connect "close" event with callback
$win->connect("destroy", "GtkWindowDestroy");

// Show window
$win->show_all();

// Test
Gtk::show_uri_on_window(
    $win,
   'https://github.com/scorninpc/php-gtk3' // on my environment open the link in external browser
);

// Start
Gtk::main();

```

Usage example in real project (to open external URL on `GtkMenuItem` activate)
https://github.com/YGGverse/Yoda/commit/a2d24145aea81b5626ccc3440a602f5779453244